### PR TITLE
Add Show Only Last Question game setting

### DIFF
--- a/src/client/components/game/QuestionLog.tsx
+++ b/src/client/components/game/QuestionLog.tsx
@@ -11,16 +11,24 @@ export function QuestionLog() {
     return null;
   }
 
-  if (questionHistory.length === 0) {
+  // Filter to only show questions asked by the current player
+  const myQuestions = questionHistory.filter(
+    (entry) => entry.askerIndex === playerIndex
+  );
+
+  if (myQuestions.length === 0) {
     return null;
   }
 
-  const getPlayerName = (askerIndex: number): string => {
-    if (askerIndex === playerIndex) {
-      return "You";
-    }
-    return session?.players[askerIndex]?.name || "Opponent";
-  };
+  // Apply the "show only last question" setting
+  const showOnlyLastQuestion = session?.showOnlyLastQuestion ?? false;
+  const displayedQuestions = showOnlyLastQuestion
+    ? myQuestions.slice(-1)
+    : myQuestions;
+
+  // Get opponent's name for answer display
+  const opponentName =
+    session?.players[playerIndex === 0 ? 1 : 0]?.name || "Opponent";
 
   return (
     <div className="paper-card p-4 sm:p-6">
@@ -29,30 +37,16 @@ export function QuestionLog() {
         className="w-full flex items-center justify-between text-left"
       >
         <h3 className="font-display text-lg text-pencil">
-          Question Log ({questionHistory.length})
+          Question Log ({displayedQuestions.length}{showOnlyLastQuestion && myQuestions.length > 1 ? ` of ${myQuestions.length}` : ""})
         </h3>
         <span className="text-pencil/60">{isExpanded ? "−" : "+"}</span>
       </button>
 
       {isExpanded && (
         <div className="mt-4 space-y-3 max-h-64 overflow-y-auto">
-          {questionHistory.map((entry: QuestionLogEntry, index: number) => (
-            <div
-              key={index}
-              className={`p-3 rounded-lg ${
-                entry.askerIndex === playerIndex
-                  ? "bg-crayon-blue/10"
-                  : "bg-sunshine/20"
-              }`}
-            >
-              <div className="flex items-start gap-2">
-                <span className="text-xs font-ui text-pencil/60 whitespace-nowrap">
-                  {getPlayerName(entry.askerIndex)}:
-                </span>
-                <p className="text-sm font-ui text-pencil flex-1">
-                  "{entry.question}"
-                </p>
-              </div>
+          {displayedQuestions.map((entry: QuestionLogEntry, index: number) => (
+            <div key={index} className="p-3 rounded-lg bg-crayon-blue/10">
+              <p className="text-sm font-ui text-pencil">"{entry.question}"</p>
               <div className="mt-1 text-right">
                 {entry.answer !== null ? (
                   <span
@@ -60,7 +54,7 @@ export function QuestionLog() {
                       entry.answer ? "text-grass" : "text-paper-red"
                     }`}
                   >
-                    {entry.answer ? "Yes" : "No"}
+                    {opponentName}: {entry.answer ? "Yes" : "No"}
                   </span>
                 ) : (
                   <span className="text-xs text-pencil/50 italic">

--- a/src/client/components/lobby/CreateGameForm.tsx
+++ b/src/client/components/lobby/CreateGameForm.tsx
@@ -9,6 +9,7 @@ export function CreateGameForm() {
   const [selectedConfig, setSelectedConfig] = useState("");
   const [playerName, setPlayerName] = useState("");
   const [isLocalMode, setIsLocalMode] = useState(false);
+  const [showOnlyLastQuestion, setShowOnlyLastQuestion] = useState(false);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -33,6 +34,7 @@ export function CreateGameForm() {
     const response = await api.games.create({
       configId: selectedConfig,
       isLocalMode,
+      showOnlyLastQuestion,
     });
 
     if (response.success && response.data) {
@@ -84,7 +86,7 @@ export function CreateGameForm() {
         </select>
       </div>
 
-      <div className="mb-6">
+      <div className="mb-4">
         <label className="flex items-center gap-3 cursor-pointer">
           <input
             type="checkbox"
@@ -96,6 +98,23 @@ export function CreateGameForm() {
             <span className="font-ui text-sm text-pencil">Local 2-Player Mode</span>
             <p className="font-ui text-xs text-pencil/60">
               Ask questions in person - only submit word guesses
+            </p>
+          </div>
+        </label>
+      </div>
+
+      <div className="mb-6">
+        <label className="flex items-center gap-3 cursor-pointer">
+          <input
+            type="checkbox"
+            checked={showOnlyLastQuestion}
+            onChange={(e) => setShowOnlyLastQuestion(e.target.checked)}
+            className="w-5 h-5 rounded border-pencil/30 text-crayon-blue focus:ring-crayon-blue"
+          />
+          <div>
+            <span className="font-ui text-sm text-pencil">Show Only Last Question</span>
+            <p className="font-ui text-xs text-pencil/60">
+              Only display the most recent question in the log
             </p>
           </div>
         </label>

--- a/src/server/game-engine.ts
+++ b/src/server/game-engine.ts
@@ -67,6 +67,7 @@ export function createGameSession(
   gridSize: GridSize,
   wordBank: WordEntry[],
   isLocalMode: boolean = false,
+  showOnlyLastQuestion: boolean = false,
 ): GameSession {
   const now = new Date();
   const expiresAt = new Date(now.getTime() + 5 * 60 * 1000); // 5 minutes
@@ -77,6 +78,7 @@ export function createGameSession(
     code: generateGameCode(),
     configId,
     isLocalMode,
+    showOnlyLastQuestion,
     phase: "waiting",
     players: [],
     gameState: {

--- a/src/server/routes/game.ts
+++ b/src/server/routes/game.ts
@@ -27,7 +27,7 @@ export async function handleCreateGame(request: Request): Promise<Response> {
       return jsonResponse({ success: false, error: "configId is required" }, 400);
     }
 
-    const result = await sessionManager.createSession(body.configId, body.isLocalMode ?? false);
+    const result = await sessionManager.createSession(body.configId, body.isLocalMode ?? false, body.showOnlyLastQuestion ?? false);
 
     if ("error" in result) {
       return jsonResponse({ success: false, error: result.error }, 400);
@@ -57,6 +57,7 @@ export function handleGetGame(code: string): Response {
     code: session.code,
     configId: session.configId,
     isLocalMode: session.isLocalMode,
+    showOnlyLastQuestion: session.showOnlyLastQuestion,
     phase: session.phase,
     players: session.players.map((p) => ({
       id: p.id,

--- a/src/server/session-manager.ts
+++ b/src/server/session-manager.ts
@@ -51,6 +51,7 @@ class SessionManager {
   async createSession(
     configId: string,
     isLocalMode: boolean = false,
+    showOnlyLastQuestion: boolean = false,
   ): Promise<GameSession | { error: string }> {
     const config = getConfig(configId);
     if (!config) {
@@ -73,6 +74,7 @@ class SessionManager {
       config.settings.gridSize,
       config.wordBank,
       isLocalMode,
+      showOnlyLastQuestion,
     );
     session.code = gameCode; // Use the verified unique code
 
@@ -349,6 +351,7 @@ class SessionManager {
         code: session.code,
         configId: session.configId,
         isLocalMode: session.isLocalMode,
+        showOnlyLastQuestion: session.showOnlyLastQuestion,
         phase: session.phase,
         players: session.players.map((p) => ({
           id: p.id,

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -121,6 +121,8 @@ export interface GameSession {
   configId: string;
   /** Whether this is a local 2-player mode (questions asked in person) */
   isLocalMode: boolean;
+  /** Whether to show only the most recent question in the log */
+  showOnlyLastQuestion: boolean;
   /** Current phase of the game */
   phase: GamePhase;
   /** Players in the session (max 2) */
@@ -139,6 +141,8 @@ export interface PublicGameSession {
   configId: string;
   /** Whether this is a local 2-player mode (questions asked in person) */
   isLocalMode: boolean;
+  /** Whether to show only the most recent question in the log */
+  showOnlyLastQuestion: boolean;
   phase: GamePhase;
   players: Array<{ id: string; name: string; connected: boolean }>;
   createdAt: string;
@@ -343,6 +347,8 @@ export interface CreateGameInput {
   configId: string;
   /** Enable local 2-player mode (questions asked in person) */
   isLocalMode?: boolean;
+  /** Show only the most recent question in the log */
+  showOnlyLastQuestion?: boolean;
 }
 
 /** Response when creating a game */


### PR DESCRIPTION
## Summary

- Add a new game-level toggle "Show Only Last Question" in the Create Game form
- When enabled, the question log displays only the most recent question instead of the full history
- The header shows "1 of N" when filtering is active to indicate total questions asked

## Changes

**Types (`src/shared/types.ts`):**
- Added `showOnlyLastQuestion` field to `GameSession`, `PublicGameSession`, and `CreateGameInput` interfaces

**Server:**
- Updated `createGameSession()` in game-engine.ts to accept and include the new setting
- Updated `createSession()` in session-manager.ts to pass through the setting
- Updated `handleCreateGame()` and `handleGetGame()` in routes/game.ts to handle the setting

**Client:**
- Added checkbox toggle in CreateGameForm.tsx below the Local Mode toggle
- Updated QuestionLog.tsx to filter displayed questions based on the setting

## Test plan
- [ ] Create a game with "Show Only Last Question" enabled
- [ ] Join from second browser and ask multiple questions
- [ ] Verify only the most recent question appears in the log
- [ ] Verify header shows "1 of N" format
- [ ] Create a game with toggle disabled
- [ ] Verify all questions appear in the log