### PR TITLE
Add functionality to list configurations owned by a specific instructor

### DIFF
--- a/src/client/lib/api.ts
+++ b/src/client/lib/api.ts
@@ -143,9 +143,16 @@ export const api = {
   },
 
   configs: {
-    list: (classId?: string) => {
-      const params = classId ? `?classId=${encodeURIComponent(classId)}` : "";
-      return request<GameConfig[]>(`/configs${params}`);
+    list: (classId?: string, ownedOnly?: boolean) => {
+      const searchParams = new URLSearchParams();
+      if (classId) {
+        searchParams.set("classId", classId);
+      }
+      if (ownedOnly) {
+        searchParams.set("ownedOnly", "true");
+      }
+      const params = searchParams.toString();
+      return request<GameConfig[]>(`/configs${params ? `?${params}` : ""}`);
     },
 
     get: (id: string) =>

--- a/src/client/pages/InstructorPage.tsx
+++ b/src/client/pages/InstructorPage.tsx
@@ -223,7 +223,7 @@ export function InstructorPage() {
   const refreshConfigs = async () => {
     setListLoading(true);
     setListError(null);
-    const response = await api.configs.list();
+    const response = await api.configs.list(undefined, true);
     if (response.success && response.data) {
       setConfigs(response.data);
     } else {

--- a/src/server/config-manager.ts
+++ b/src/server/config-manager.ts
@@ -39,6 +39,20 @@ export function listConfigs(instructorId?: string): GameConfig[] {
   return rows.map(rowToConfig);
 }
 
+/** List only configurations created by a specific instructor */
+export function listOwnedConfigs(instructorId: string): GameConfig[] {
+  const db = getDb();
+  const rows = db
+    .query<GameConfigRow, [string]>(
+      `SELECT id, name, config_json, owner_id, is_system_template, is_public, created_at, updated_at
+       FROM game_configs
+       WHERE owner_id = ?
+       ORDER BY updated_at DESC`
+    )
+    .all(instructorId);
+  return rows.map(rowToConfig);
+}
+
 /** List only public configurations and system templates (for unauthenticated users) */
 export function listPublicConfigs(): GameConfig[] {
   const db = getDb();

--- a/src/server/routes/api.ts
+++ b/src/server/routes/api.ts
@@ -1,6 +1,7 @@
 import type { GameConfig, GameConfigInput, Instructor } from "@shared/types";
 import {
   listConfigs,
+  listOwnedConfigs,
   listPublicConfigs,
   getConfig,
   createConfig,
@@ -42,11 +43,12 @@ async function getInstructorFromRequest(
 export async function handleListConfigs(request: Request): Promise<Response> {
   const url = new URL(request.url);
   const classId = url.searchParams.get("classId");
+  const ownedOnly = url.searchParams.get("ownedOnly") === "true";
   const instructor = await getInstructorFromRequest(request);
 
   let configs: GameConfig[];
   if (instructor) {
-    configs = listConfigs(instructor.id);
+    configs = ownedOnly ? listOwnedConfigs(instructor.id) : listConfigs(instructor.id);
   } else if (classId) {
     const cls = getClassById(classId);
     configs = cls ? listConfigs(cls.instructorId) : listPublicConfigs();


### PR DESCRIPTION
- Introduced listOwnedConfigs function to retrieve configurations based on instructor ID.
- Updated handleListConfigs route to conditionally fetch owned configurations.
- Modified API client to support an optional ownedOnly parameter for fetching configs.
- Adjusted InstructorPage to call the updated API for listing configurations.